### PR TITLE
AttributeError: 'file' object has no attribute 'charset' in utils.py

### DIFF
--- a/tyrs/utils.py
+++ b/tyrs/utils.py
@@ -27,4 +27,4 @@ def cut_attag(name):
     return name
 
 def encode(string):
-    return string.encode(sys.stdout.charset)
+    return string.encode(sys.stdout.encoding)


### PR DESCRIPTION
Once corrected issue with encodings (https://github.com/Nic0/tyrs/issues/49), another bug was introduced. Traceback:

``` python
Traceback (most recent call last):
  File "/usr/bin/tyrs", line 5, in <module>
    pkg_resources.run_script('tyrs==0.3.1', 'tyrs')
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 468, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 1201, in run_script
    execfile(script_filename, namespace, namespace)
  File "/usr/lib/python2.7/site-packages/tyrs-0.3.1-py2.7.egg/EGG-INFO/scripts/tyrs", line 16, in <module>
    main()
  File "/usr/lib/python2.7/site-packages/tyrs-0.3.1-py2.7.egg/tyrs/tyrs.py", line 61, in main
    init_conf()
  File "/usr/lib/python2.7/site-packages/tyrs-0.3.1-py2.7.egg/tyrs/tyrs.py", line 73, in init_conf
    conf = config.Config(arguments())
  File "/usr/lib/python2.7/site-packages/tyrs-0.3.1-py2.7.egg/tyrs/config.py", line 48, in __init__
    self.new_account()
  File "/usr/lib/python2.7/site-packages/tyrs-0.3.1-py2.7.egg/tyrs/config.py", line 116, in new_account
    choice = self.ask_service()
  File "/usr/lib/python2.7/site-packages/tyrs-0.3.1-py2.7.egg/tyrs/config.py", line 124, in ask_service
    message.print_ask_service(self.config_file)
  File "/usr/lib/python2.7/site-packages/tyrs-0.3.1-py2.7.egg/tyrs/message.py", line 86, in print_ask_service
    print encode(_('There is no profile detected.'))
  File "/usr/lib/python2.7/site-packages/tyrs-0.3.1-py2.7.egg/tyrs/utils.py", line 30, in encode
    return string.encode(sys.stdout.charset)
AttributeError: 'file' object has no attribute 'charset'
```
