### PR TITLE
Don't crash on lowercase control-sequence in config.

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -283,7 +283,7 @@ class Config(object):
         if ch[0] == '^':
             i = 0
             while i <= 31:
-                if curses.ascii.unctrl(i) == ch:
+                if curses.ascii.unctrl(i) == ch.upper():
                     return i
                 i +=1
         return ord(ch)


### PR DESCRIPTION
It's ok to specify a control-sequence in lower case (^c in addition to ^C).
