### PR TITLE
Fix proxy config at first launch

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -103,6 +103,8 @@ class Config(object):
                 value = 1
             elif self.params[p] == False:
                 value = 0
+            elif self.params[p] == None:
+                continue
             else:
                 value = self.params[p]
 


### PR DESCRIPTION
When generating fresh config, proxy value set
to None, resulting in proxy url http://None
at next launch.

As config reader doesnt convert string "None"
to literal None, solution is to simply skip
None values at write.
