### PR TITLE
List branch

### DIFF
--- a/src/tyrs/tweets.py
+++ b/src/tyrs/tweets.py
@@ -574,8 +574,8 @@ class ApiPatch(Api):
           <= 200 [optional]
           page: specifies the page to retrieve [optional]
           '''
-        url = 'https://api.twitter.com'
-        path_elements = ['1','lists','statuses.json']
+        url = self.base_url
+        path_elements = ['lists','statuses.json']
         params = {'slug':slug,
                   'owner_screen_name':user,
                   'include_entities':'true'}


### PR DESCRIPTION
Simple change, addressing the issues from the previous pull request.

> Python-twitter module has a List object that handle lists. 
> I don't know if identica support lists, but it wont works as you write the twitter url inside the code.

List object does not retrieve statuses, so I put a GetListStatuses method in ApiPatch 
I'm now using base_url. I don't know if identica support them either.
